### PR TITLE
Add more precise rendering capabilities

### DIFF
--- a/src/sh-tabs.js
+++ b/src/sh-tabs.js
@@ -122,7 +122,7 @@ class ShTabs extends React.Component {
     }
 }
 
-ShTabs.PropTypes = {
+ShTabs.propTypes = {
     tabs: React.PropTypes.array.isRequired,
     type: React.PropTypes.oneOf(['standard', 'card']),
     onChange: React.PropTypes.func,

--- a/src/sh-tabs.js
+++ b/src/sh-tabs.js
@@ -105,6 +105,7 @@ class ShTabs extends React.Component {
             tabs,
             type,
             onChange,
+            afterFirstRender,
             ...other
         } = this.props;
 
@@ -121,7 +122,7 @@ class ShTabs extends React.Component {
     }
 }
 
-ShTabs.propTypes = {
+ShTabs.PropTypes = {
     tabs: React.PropTypes.array.isRequired,
     type: React.PropTypes.oneOf(['standard', 'card']),
     onChange: React.PropTypes.func,

--- a/src/sh-tabs.js
+++ b/src/sh-tabs.js
@@ -14,6 +14,11 @@ class ShTabs extends React.Component {
         this.selectTab = this.selectTab.bind(this);
     }
 
+    componentDidMount() {
+        const { afterFirstRender } = this.props;
+        if (afterFirstRender) { afterFirstRender(); }
+    }
+
     selectTab(index) {
         return () => {
             if (this.state.currentTab === index) {
@@ -119,13 +124,15 @@ class ShTabs extends React.Component {
 ShTabs.propTypes = {
     tabs: React.PropTypes.array.isRequired,
     type: React.PropTypes.oneOf(['standard', 'card']),
-    onChange: React.PropTypes.func
+    onChange: React.PropTypes.func,
+    afterFirstRender: React.PropTypes.func
 };
 
 ShTabs.defaultProps = {
     tabs: [],
     type: 'standard',
-    onChange: _.noop
+    onChange: _.noop,
+    afterFirstRender: _.noop
 };
 
 export default ShTabs;

--- a/src/sh-tabs.spec.js
+++ b/src/sh-tabs.spec.js
@@ -151,6 +151,22 @@ describe('ShTabs', function() {
             expect(tabOld1).toBe(0);
             expect(tabNew1).toBe(1);
         });
+
+        it('calls afterFirstRender prop on mount', function() {
+            let tabs = [
+                {header: 'header1', content: 'content1'},
+                {header: <div>header2</div>, content: <div>content2</div>},
+            ];
+            let props = {
+                afterFirstRender: function() {}
+            };
+
+            spyOn(props, 'afterFirstRender');
+
+            TestUtils.renderIntoDocument(<ShTabs type="standard" tabs={tabs} afterFirstRender={props.afterFirstRender} />);
+
+            expect(props.afterFirstRender).toHaveBeenCalledWith();
+        });
     });
 
     describe('type:card', () => {


### PR DESCRIPTION
Reloading (Rendering) of content for tab (table) from props is not immediate.
State has data, but the tab component has not rendered it yet and there does not appear to be another way to know if the table has been drawn to the screen yet.
Naturally, open to alternatives.
Add afterFirstRender for more precise rendering and loading.
